### PR TITLE
Fixed AMD boilerplate to work with loaders that scan the factory function for `require` calls

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -3,12 +3,10 @@
          forin: false */
 /*global define: true */
 
-(typeof define === "undefined" ? function ($) { $(require, exports, module) } : define)(function (require, exports, module, undefined) {
+(function(define){
+define(["exports", "./utils"], function(exports, utils, undefined){
 
 "use strict";
-
-var utils = require("./utils")
-
 
 /**
  * The `AssertionError` is defined in assert.
@@ -330,3 +328,13 @@ function isArrayEquivalent(a, b, stack) {
 }
 
 });
+})(typeof define != "undefined" ?
+    define: // AMD/RequireJS format if available
+    function(deps, factory){
+        // CommonJS environment, like NodeJS
+        deps = [exports].concat(deps.slice(1).map(function(name){
+            return require(name);
+        }));
+        factory.apply(this, deps);
+    }
+);

--- a/engines/browser/logger.js
+++ b/engines/browser/logger.js
@@ -4,11 +4,12 @@
 /*global define: true, document: true */
 
 
-(typeof define === "undefined" ? function ($) { $(require, exports, module) } : define)(function (require, exports, module, undefined) {
+(function(define){
+define(["exports", "../../utils"], function(exports, utils, undefined){
 
 "use strict";
 
-var toSource = require('../../utils').source
+var toSource = utils.source
 
 var INDENT = '  '
 
@@ -104,3 +105,13 @@ function Logger(options) {
 exports.Logger = Logger
 
 });
+})(typeof define != "undefined" ?
+    define: // AMD/RequireJS format if available
+    function(deps, factory){
+        // CommonJS environment, like NodeJS
+        deps = [exports].concat(deps.slice(1).map(function(name){
+            return require(name);
+        }));
+        factory.apply(this, deps);
+    }
+);

--- a/engines/browser/test.js
+++ b/engines/browser/test.js
@@ -3,15 +3,25 @@
          forin: false */
 /*global define: true */
 
-(typeof define === "undefined" ? function ($) { $(require, exports, module) } : define)(function (require, exports, module, undefined) {
+(function(define){
+define(["exports", "./logger", "../../test", "../../assert"], function(exports, logger, test, assert, undefined){
 
 
-var Logger = require('./logger').Logger
-var test = require('../../test')
+var Logger = logger.Logger;
 
-exports.Assert = require('../../assert').Assert
+exports.Assert = assert.Assert
 exports.run = function run(units, logger) {
   test.run(units, logger || new Logger())
 }
 
 });
+})(typeof define != "undefined" ?
+    define: // AMD/RequireJS format if available
+    function(deps, factory){
+        // CommonJS environment, like NodeJS
+        deps = [exports].concat(deps.slice(1).map(function(name){
+            return require(name);
+        }));
+        factory.apply(this, deps);
+    }
+);

--- a/test.js
+++ b/test.js
@@ -2,11 +2,12 @@
 /*jshint asi: true undef: true es5: true node: true devel: true
          forin: true */
 /*global define: true */
-(typeof define === "undefined" ? function ($) { $(require, exports, module) } : define)(function (require, exports, module, undefined) {
+(function(define){
+define(["exports", "./assert"], function(exports, assert, undefined){
 
 'use strict';
 
-var Assert = require('./assert').Assert
+var Assert = assert.Assert;
 
 var ERR_COMPLETED_ASSERT = 'Assert in completed test'
 var ERR_COMPLETED_COMPLETE = 'Attemt to complete test more then one times'
@@ -89,3 +90,13 @@ exports.run = function run(units, logger) {
 
 
 });
+})(typeof define != "undefined" ?
+    define: // AMD/RequireJS format if available
+    function(deps, factory){
+        // CommonJS environment, like NodeJS
+        deps = [exports].concat(deps.slice(1).map(function(name){
+            return require(name);
+        }));
+        factory.apply(this, deps);
+    }
+);

--- a/utils.js
+++ b/utils.js
@@ -3,7 +3,8 @@
          forin: false */
 /*global define: true */
 
-(typeof define === "undefined" ? function ($) { $(require, exports, module) } : define)(function (require, exports, module, undefined) {
+(function(define){
+define(["exports"], function(exports, undefined){
 
 "use strict";
 
@@ -343,3 +344,13 @@ exports.source = function (value, indentation, limit) {
 };
 
 });
+})(typeof define != "undefined" ?
+    define: // AMD/RequireJS format if available
+    function(deps, factory){
+        // CommonJS environment, like NodeJS
+        deps = [exports].concat(deps.slice(1).map(function(name){
+            return require(name);
+        }));
+        factory.apply(this, deps);
+    }
+);


### PR DESCRIPTION
AMD loaders like Dojo's scan the string returned by `factory.toString` for `require` calls and append the dependencies to the list of modules to fetch. Because of this, `undefined` in the factory function ends up being set to the first module fetched. It's also best to avoid the `require` scanning since it's inefficient. I've updated the boilerplate to be both AMD and CommonJS compatible.
