### PR TITLE
Support for objects created via Object.create(null)

### DIFF
--- a/test/assert.js
+++ b/test/assert.js
@@ -96,21 +96,28 @@ exports["test correctness of `assert.equal`"] = function (assert) {
 }
 
 exports["test correctness of `assert.deepEqual`"] = function (assert) {
-  var valid, invalid, report
+  var valid, invalid, report, toString
   valid = [
     [ [], [] ],
     [ {}, {} ],
+    [ Object.create(null), Object.create(null) ],
   ]
   invalid = [
     [ [], undefined ],
     [ [], [1] ]
   ]
   report = null
+  toString = function (x) {
+    if (x.toString) {
+      return x.toString();
+    }
+    return Object.prototype.toString.call(x)
+  }
 
   run({
     "test fixture": function (assert) {
       valid.forEach(function (value, index) {
-        var message = "`" + value[0] + "` is deepEqual of `" + value[1] + "`"
+        var message = "`" + toString(value[0]) + "` is deepEqual of `" + toString(value[1]) + "`"
         assert.deepEqual(value[0], value[1], message)
       })
 

--- a/utils.js
+++ b/utils.js
@@ -183,6 +183,7 @@ exports.isJSON = function (value) {
  * function from different iframe / jetpack module / sandbox).
  */
 function instanceOf(value, Type) {
+  var constructor;
   var isConstructorNameSame;
   var isConstructorSourceSame;
 
@@ -194,8 +195,9 @@ function instanceOf(value, Type) {
   // of the value"s prototype has same name and source we assume that it"s an
   // instance of the Type.
   if (!isInstanceOf && value) {
-    isConstructorNameSame = value.constructor.name === Type.name;
-    isConstructorSourceSame = String(value.constructor) == String(Type);
+    constructor = value.constructor;
+    isConstructorNameSame = constructor && (constructor.name === Type.name);
+    isConstructorSourceSame = String(constructor) == String(Type);
     isInstanceOf = (isConstructorNameSame && isConstructorSourceSame) ||
                     instanceOf(Object.getPrototypeOf(value), Type);
   }


### PR DESCRIPTION
Currently `assert.deepEqual` crashes when we compare objects that derive from `null`. This pull request fixes that.
